### PR TITLE
Set lines for "Allowed Roles" in pv-inverter to active

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -47,7 +47,7 @@ tank:
 # https://github.com/victronenergy/venus/wiki/dbus#pv-inverters
 pvinverter:
   ProductId:
-    default: 45069 # 0xB00D, ESS Demo mode uses 45058
+    default: 45069 # 45069 = ET340, 45068 = ET112, 0xB00D, ESS Demo mode uses 45058
   CustomName:
     default: "My PV Inverter"
     persist: true
@@ -65,12 +65,12 @@ pvinverter:
     default: 7
     min: 0
     max: 10
-#  AllowedRoles:
-#    default: '["grid", "pvinverter", "genset", "acload"]'
-#  Role:
-#    description: "grid, pvinverter, genset, acload"    
-#    persist: true
-#    default: "pvinverter"
+  AllowedRoles:
+    default: ["grid", "pvinverter", "genset", "acload"]
+  Role:
+    description: "grid, pvinverter, genset, acload"    
+    persist: true
+    default: "pvinverter"
 #  PhaseConfig:
 #    description: "0=3P.n; 1=3P.l; 2=2P; 3=1P; 4=3P"
 #    persist: true


### PR DESCRIPTION
Hello,
as written in https://github.com/freakent/dbus-mqtt-devices/issues/23 the PR activates the "allowed roles" lines for the pv-inverter to change it's position between AC-IN and AC-OUT:

![image](https://user-images.githubusercontent.com/47776842/203374206-be73917c-6fdb-4d3a-b77c-e90b0e703ba9.png)

This is necessary for easier integration of Hoymiles inverters to push there values with the dbus-mqqt-devices driver automatically from Open-DTU to VRM portal. See also PR https://github.com/tbnobody/OpenDTU/pull/377

Thanks,
Peter

