### PR TITLE
Add JK BMS battery service

### DIFF
--- a/samples/battery-simulator.py
+++ b/samples/battery-simulator.py
@@ -1,0 +1,69 @@
+import paho.mqtt.client as mqtt
+import json
+import copy
+
+clientid = "jkmqtt"
+
+registration = {
+  "clientId": clientid,
+  "connected": 1,
+  "version": "v1.0",
+  "services": {
+    "jkbms2": "battery"
+  }
+}
+
+unregister = copy.deepcopy(registration)
+unregister["connected"] = 0
+
+data = {
+    "System/MinCellVoltage":  3.325,
+    "System/MaxCellVoltage":  3.326,
+    "Dc/0/Temperature":  13,
+    "Dc/0/Voltage":  26.6,
+    "Dc/0/Current":  -2.48,
+    "Dc/0/Power":  -65,
+    "Soc":  78,
+    "System/NrOfCellsPerBattery":  8,
+    "Capacity":  195,
+    "InstalledCapacity":  250,
+    "Io/AllowToCharge": 1,
+    "Io/AllowToDischarge": 1,
+    "System/NrOfModulesBlockingCharge": 0,
+    "System/NrOfModulesBlockingDischarge": 0,
+    "System/NrOfCellsPerBattery": 8,
+}
+
+
+def on_connect(client, userdata, flags, rc):
+    print("Connected with result code "+str(rc))
+    # Subscribing in on_connect() means that if we lose the connection and
+    # reconnect then subscriptions will be renewed.
+    client.subscribe("device/{}/DBus".format(clientid))
+    client.publish("device/{}/Status".format(clientid), json.dumps(registration))
+
+# The callback for when a PUBLISH message is received from the server.
+def on_message(client, userdata, msg):
+    print(msg.topic+" "+str(msg.payload))
+
+    dbus_msg = json.loads(msg.payload)
+    portalId = dbus_msg.get("portalId")
+    deviceId = dbus_msg.get("deviceInstance").get("jkbms2") # UPDATE THIS
+
+    for key in data:
+        topic = "W/{}/battery/{}/{}".format(portalId, deviceId, key) # UPDATE THIS
+        print("{} = {}".format(topic, data.get(key) ) )
+        client.publish(topic, json.dumps({ "value": data.get(key) }) )
+
+client = mqtt.Client()
+client.on_connect = on_connect
+client.on_message = on_message
+client.will_set("device/{}/Status".format(clientid), json.dumps(unregister)) # UPDATE THIS
+
+client.connect("venus.local", 1883, 60)
+
+# Blocking call that processes network traffic, dispatches callbacks and
+# handles reconnecting.
+# Other loop*() functions are available that give a threaded interface and a
+# manual interface.
+client.loop_forever()

--- a/services.yml
+++ b/services.yml
@@ -343,3 +343,58 @@ evcharger:
     default: 1
     min: 0
     max: 20
+
+# https://github.com/victronenergy/venus/wiki/dbus#battery
+battery:
+  ProductId:
+    default: 65535 # 0xFFFF
+  CustomName:
+    default: "MQTT BMS"
+    persist: true
+  Capacity:
+    format: "{} Ah"
+  InstalledCapacity:
+    format: "{} Ah"
+  Dc/0/Voltage:
+    format: "{} V"
+    description: "V DC"
+  Dc/0/Current:
+    format: "{} A"
+    description: "A"
+  Dc/0/Power:
+    format: "{} W"
+    description: "W"
+  Dc/0/Temperature:
+    format: "{} °C"
+    description: "T1"
+  Soc:
+    format: "{} %"
+    description: "State of charge"
+  Balancing:
+    description: "0 = off, 1 = on"
+  Io/AllowToCharge:
+    description: "0 = off, 1 = on"
+  Io/AllowToDischarge:
+    description: "0 = off, 1 = on"
+  ConsumedAmphours:
+    format: "{} Ah"
+    description: "Ah"
+  System/MinCellVoltage:
+    format: "{} V"
+    description: "V DC"
+  System/MaxCellVoltage:
+    format: "{} V"
+    description: "V DC"
+  System/NrOfCellsPerBattery:
+    format: "{}"
+    description: "Cells per battery"
+  System/NrOfBatteries:
+    format: "{}"
+    description: "Number of batteries"
+  System/BatteriesParallel:
+    format: "{}"
+    description: "None"
+  System/BatteriesSeries:
+    format: "{}"
+    description: "None"
+


### PR DESCRIPTION
Follow-up of https://github.com/freakent/dbus-mqtt-devices/pull/116

Following changes were made to support integration with JK BMS (https://www.jkbms.com/).:
 - cleaned up whitespace in yml
 - added simulator script
 - removed "persist" attributes for non-settings
 - rebased to 0.9.0dev

Some screenshots:

![Bildschirmfoto_20250422_133224-3](https://github.com/user-attachments/assets/55c66a8e-21fd-4aa3-a82d-fb7037dcc6a4)
![Bildschirmfoto_20250422_133028](https://github.com/user-attachments/assets/75aaeb82-543e-4df6-a98e-b6f2d84e8888)
![Bildschirmfoto_20250422_133015](https://github.com/user-attachments/assets/b2845b7b-0eed-471b-b981-bf19e0f1191b)
![Bildschirmfoto_20250422_131537](https://github.com/user-attachments/assets/037afce5-cd98-4518-9b24-709249619c03)
![Bildschirmfoto_20250422_131516-1](https://github.com/user-attachments/assets/1f262ed0-1890-40a3-af6f-b8173815271e)
![Bildschirmfoto_20250422_131516](https://github.com/user-attachments/assets/fe23c704-21e9-4f2e-9b1d-254843fcb6bc)
![Bildschirmfoto_20250422_131447](https://github.com/user-attachments/assets/66843225-bed8-4f80-a76b-66ba72438f89)
![Bildschirmfoto_20250422_131421](https://github.com/user-attachments/assets/c27238d5-0c40-467b-b51f-1ace1b0300e7)
![Bildschirmfoto_20250422_131401](https://github.com/user-attachments/assets/f18e2c76-e53e-4436-a817-5e8a1b60d26c)
![Bildschirmfoto_20250422_131334-2](https://github.com/user-attachments/assets/da71968d-439d-4c75-80b6-e9ea2cfafee3)
![Bildschirmfoto_20250422_131334-1](https://github.com/user-attachments/assets/be5d8af7-fe4e-448a-9f74-d4cfbd808564)
![Bildschirmfoto_20250422_131334](https://github.com/user-attachments/assets/376854c0-7e97-45f4-9bd5-e3afabc84755)
![Bildschirmfoto_20250422_131254](https://github.com/user-attachments/assets/9ff10cdc-d8bf-4091-aecc-c5b7b1649186)
